### PR TITLE
Fixing CMAKE_CXX_FLAGS modification in plugins.

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(
   ${Qt5Core_INCLUDE_DIRS}
 )
 link_directories(${GAZEBO_LIBRARY_DIRS})
-list(APPEND CMAKE_CXX_FLAGS "${GAZEBO_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 
 set (plugins
   LensFlareVisualPlugin


### PR DESCRIPTION
`set()` and `unset()` are the recommended functions for modifying [Environmental Variables](https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#cmake-language-environment-variables) in CMake. Using the `list()` function does not have the proper scope and also appears to cause string mangling. This PR fixes the ability to modify CMAKE_CXX_FLAGS at a higher level (such as on the command line during the Melodic build of Autoware).